### PR TITLE
feat: remove provider reg from launch script

### DIFF
--- a/launchmevcommit
+++ b/launchmevcommit
@@ -173,4 +173,8 @@ done
 
 sleep 3
 
+if [ "${NODE_TYPE}" == "provider" ]; then
+    echo -e "\033[31m[\033[34m*\033[31m]\033[33m Next, to register and stake as a provider, visit https://docs.primev.xyz/get-started/providers/registering-a-provider \033[0m"
+fi
+
 wait $server_pid

--- a/launchmevcommit
+++ b/launchmevcommit
@@ -4,7 +4,6 @@
 DEVENV=false
 NODE_TYPE=""
 MEV_COMMIT_VERSION="v0.3.1"
-MEV_COMMIT_LOG_LEVEL="info"
 ROOT_DIRECTORY="${HOME}/.mev-commit"
 RPC_URL="https://chainrpc.testnet.mev-commit.xyz"
 FAUCET_URL="http://faucet.testnet.mev-commit.xyz"
@@ -173,20 +172,5 @@ while true; do
 done
 
 sleep 3
-# Check i Node_Type is provider
-if [ "${NODE_TYPE}" == "provider" ]; then
-    stake_amount=$(${HOME}/.foundry/bin/cast call ${PROVIDER_REGISTRY_CONTRACT} 'checkStake(address)' ${ADDRESS} --rpc-url ${RPC_URL})
-    if [[ $stake_amount =~ ^0x0+$ ]]; then
-	      echo -e "\033[31m[\033[34m*\033[31m]\033[33m Registering ${ADDRESS} as a provider with 50 ether stake \033[0m"
-
-        # Use the RPC URL variable in the cast send command
-        if ! ${HOME}/.foundry/bin/cast send ${PROVIDER_REGISTRY_CONTRACT} "registerAndStake()" ${ADDRESS} --rpc-url "${RPC_URL}" --private-key ${KEY} --value 50ether > /dev/null 2>&1; then
-            echo "Error: Failed to send provider registration transaction."
-            exit 1
-        fi
-    else
-	      echo -e "\033[31m[\033[34m*\033[31m]\033[33m The address ${ADDRESS} is already registered as provider \033[0m"
-    fi
-fi
 
 wait $server_pid


### PR DESCRIPTION
Now that providers must register with their BLS pubkey, the provider reg step must be done manually by the provider